### PR TITLE
spawning adjustments

### DIFF
--- a/config/lycanitesmobs/creatures/eechetik.json
+++ b/config/lycanitesmobs/creatures/eechetik.json
@@ -1,10 +1,10 @@
 {
   "name": "eechetik",
   "class": "com.lycanitesmobs.elementalmobs.entity.EntityEechetik",
-  "loadDefault": true,
+  "loadDefault": false,
   "enabled": true,
   "spawning": {
-    "enabled": true,
+    "enabled": false,
     "spawners": [],
     "disableSubspecies": false,
     "dimensionIds": [],

--- a/config/lycanitesmobs/elementalmobs-general.cfg
+++ b/config/lycanitesmobs/elementalmobs-general.cfg
@@ -2,7 +2,7 @@
 
 features {
     # Set to false to stop Aegis from protecting village chests.
-    B:"Aegis Chest Protection"=true
+    B:"Aegis Chest Protection"=false
 
     # Set to false to disable Lifeleak from Faebolts fired by scared Nymphs.
     B:"Nymph Fae Bolt Lifeleak Enabled"=false

--- a/config/lycanitesmobs/lycanitesmobs-general.cfg
+++ b/config/lycanitesmobs/lycanitesmobs-general.cfg
@@ -304,7 +304,7 @@ extras {
 
 fire {
     # If set to false, when the doFireTick gamerule is set to false, instead of removing all custom fire such as Hellfire, the fire simply stops spreading instead, this is useful for decorative fire on adventure maps and servers.
-    B:"Remove On No Fire Tick"=true
+    B:"Remove On No Fire Tick"=false
 }
 
 
@@ -406,7 +406,7 @@ gui {
 
 "mob variations" {
     # The maximum size scale mobs can randomly spawn at.
-    D:"Random Size Max"=1.15
+    D:"Random Size Max"=1.50
 
     # The minimum size scale mobs can randomly spawn at.
     D:"Random Size Min"=0.85

--- a/config/lycanitesmobs/lycanitesmobs-spawning.cfg
+++ b/config/lycanitesmobs/lycanitesmobs-spawning.cfg
@@ -41,16 +41,16 @@
     B:"Master Spawn Dimensions Whitelist"=false
 
     # When spawned form a vanilla spawner, this is how far a mob should search from in blocks when checking how many of its kind have already spawned. Custom Spawners have it defined in their json file instead.
-    D:"Mob Limit Search Range"=32.0
+    D:"Mob Limit Search Range"=64.0
 
     # The limit of how many mobs of the same type (peaceful or not peaceful) can spawn within the limit search range. For individual creature species limits, see the creature json configs.
-    I:"Mob Type Limit"=64
+    I:"Mob Type Limit"=32
 
     # If true, when water mobs spawn, instead of checking the light level of the block the mob is spawning at, the light level of the surface (if possible) is checked. This stops mobs like Jengus from spawning at the bottom of deep rivers during the day, set to false for the old way.
     B:"Use Surface Light Level"=true
 
     # Scales the spawn weights of all mobs from this mod. For example, you can use this to quickly half the spawn rates of mobs from this mod compared to vanilla/other mod mobs by setting it to 0.5.
-    D:"Weight Scale"=1.0
+    D:"Weight Scale"=0.9
 }
 
 

--- a/config/lycanitesmobs/spawners/fire.json
+++ b/config/lycanitesmobs/spawners/fire.json
@@ -2,7 +2,7 @@
   "name": "fire",
   "type": "spawner",
   "enabled": true,
-  "loadDefault": true,
+  "loadDefault": false,
   "mobCountMin": 8,
   "ignoreDimensions": true,
   "ignoreBiomes": true,
@@ -11,7 +11,7 @@
   "triggers": [
     {
       "type": "world",
-      "chance": 0.5,
+      "chance": 0.25,
       "tickRate": 400
     }
   ],

--- a/config/lycanitesmobs/spawners/frostfire.json
+++ b/config/lycanitesmobs/spawners/frostfire.json
@@ -2,7 +2,7 @@
   "name": "frostfire",
   "type": "spawner",
   "enabled": true,
-  "loadDefault": true,
+  "loadDefault": false,
   "mobCountMin": 8,
   "ignoreDimensions": true,
   "ignoreBiomes": true,
@@ -11,7 +11,7 @@
   "triggers": [
     {
       "type": "world",
-      "chance": 0.5,
+      "chance": 0.25,
       "tickRate": 400
     }
   ],

--- a/config/lycanitesmobs/spawners/lava.json
+++ b/config/lycanitesmobs/spawners/lava.json
@@ -2,7 +2,7 @@
   "name": "lava",
   "type": "spawner",
   "enabled": true,
-  "loadDefault": true,
+  "loadDefault": false,
   "mobCountMin": 4,
   "ignoreDimensions": true,
   "ignoreBiomes": true,
@@ -11,7 +11,7 @@
   "triggers": [
     {
       "type": "world",
-      "chance": 0.25,
+      "chance": 0.10,
       "tickRate": 400
     }
   ],


### PR DESCRIPTION
eechetik is very op with its aoe poison. Recommend disabling until we find a proper solution.

All aegis will aggro any players who opens ANY chest within the confines of a player village. This includes chests that the player himself placed. They will swarm. Recommend disabling.

Recommend to remove fire spread as discussed.

Small increase in max mob size chance upon spawning. This is a fun change, especially for those who try to hunt for "cool" mounts and pets.

Some general spawning configs. Global weight reduction to 0.9.  Lava and frostfire chances reduced by 60%.